### PR TITLE
fix: Support legacy /resources/sermon.rss URL

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   devise_for :users
   ActiveAdmin.routes(self)
 
+  get 'resources/sermon', to: 'resources#index', defaults: { format: :rss }
+
   resources :resources, only: %i[index show] do
     collection do
       scope module: :resources do


### PR DESCRIPTION
Adds a route so the old `/resources/sermon.rss` URL continues to serve the RSS feed directly, preserving compatibility with Apple Podcasts, Spotify, and any other subscribers still referencing it.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)